### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/fr.natron.Natron.json
+++ b/fr.natron.Natron.json
@@ -344,24 +344,7 @@
                 "/share/aclocal"
             ]
         },
-        {
-            "name": "openjpeg",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz",
-                    "sha256": "3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a"
-                }
-            ],
-            "cleanup": [
-                "/bin",
-                "/include"
-            ]
-        },
+        "shared-modules/openjpeg/openjpeg.json",
         {
             "name": "libraw",
             "config-opts": [


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also
brings a couple of immediate wins: the latest version includes some
bugs and security fixes, and the cmake/cleanup config results in a
slightly faster and smaller build.